### PR TITLE
Workbook improvements

### DIFF
--- a/apiManagement.bicep
+++ b/apiManagement.bicep
@@ -124,11 +124,17 @@ resource apiDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2023-0
     metrics: true
     frontend: {
       request: {
+        headers: [
+          'custom-headers'
+        ]
         body: {
           bytes: 8192
         }
       }
       response: {
+        headers: [
+          'custom-headers'
+        ]
         body: {
           bytes: 8192
         }
@@ -136,11 +142,17 @@ resource apiDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2023-0
     }
     backend: {
       request: {
+        headers: [
+          'custom-headers'
+        ]
         body: {
           bytes: 8192
         }
       }
       response: {
+        headers: [
+          'custom-headers'
+        ]
         body: {
           bytes: 8192
         }

--- a/workbook_template.json
+++ b/workbook_template.json
@@ -2,104 +2,120 @@
     "version": "Notebook/1.0",
     "items": [
         {
-            "type": 1,
+            "type": 12,
             "content": {
-                "json": "# OpenAI Requests\n---\n"
-            },
-            "name": "text - 2"
-        },
-        {
-            "type": 1,
-            "content": {
-                "json": "Click on a row to view the details of that request.",
-                "style": "info"
-            },
-            "name": "text - 6"
-        },
-        {
-            "type": 3,
-            "content": {
-                "version": "KqlItem/1.0",
-                "query": "requests\n| where operation_Name == \"OpenAIProxy;rev=1 - Completions_Create\" or operation_Name == \"OpenAIProxy;rev=1 - ChatCompletions_Create\"\n| extend requestId = customDimensions.[\"Request Id\"]\n| extend Prompt = parse_json(tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Request-Body\"])).messages[-1].content))))\n| extend Generation = parse_json(tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).choices))[0].message)).content\n| extend promptTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).prompt_tokens\n| extend completionTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).completion_tokens\n| extend totalTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).total_tokens\n| project timestamp, requestId, Prompt, Generation, promptTokens, completionTokens, totalTokens, round(duration,2), operation_Name",
-                "size": 0,
-                "showRefreshButton": true,
-                "exportFieldName": "requestId",
-                "exportParameterName": "SelectedRequest",
-                "exportDefaultValue": "none",
-                "exportToExcelOptions": "all",
-                "queryType": 0,
-                "resourceType": "microsoft.insights/components",
-                "gridSettings": {
-                    "filter": true,
-                    "sortBy": [
-                        {
-                            "itemKey": "timestamp",
-                            "sortOrder": 2
-                        }
-                    ]
-                },
-                "sortBy": [
+                "version": "NotebookGroup/1.0",
+                "groupType": "editable",
+                "loadType": "explicit",
+                "items": [
                     {
-                        "itemKey": "timestamp",
-                        "sortOrder": 2
+                        "type": 9,
+                        "content": {
+                            "version": "KqlParameterItem/1.0",
+                            "parameters": [
+                                {
+                                    "id": "46ad48fc-6150-4717-9bb4-6bac5766dc76",
+                                    "version": "KqlParameterItem/1.0",
+                                    "name": "SelectedCustomParam",
+                                    "type": 2,
+                                    "query": "requests\n| extend CustomHeaders = parse_json(tostring(customDimensions.[\"Request-custom-headers\"]))\n| mv-expand bagexpansion=array CustomHeaders\n| summarize by tostring(CustomHeaders[0])\n",
+                                    "typeSettings": {
+                                        "additionalResourceOptions": [],
+                                        "showDefault": false
+                                    },
+                                    "timeContext": {
+                                        "durationMs": 86400000
+                                    },
+                                    "queryType": 0,
+                                    "resourceType": "microsoft.insights/components",
+                                    "value": "user"
+                                }
+                            ],
+                            "style": "pills",
+                            "queryType": 0,
+                            "resourceType": "microsoft.insights/components"
+                        },
+                        "name": "parameters - 7"
+                    },
+                    {
+                        "type": 3,
+                        "content": {
+                            "version": "KqlItem/1.0",
+                            "query": "let selectedParam = '{SelectedCustomParam}';\nlet summary = \n    requests\n    | where operation_Name == \"OpenAIProxy;rev=1 - Completions_Create\" or operation_Name == \"OpenAIProxy;rev=1 - ChatCompletions_Create\"\n    | extend CustomHeaders = parse_json(tostring(customDimensions.[\"Request-custom-headers\"]))\n    | extend SelectedParamValue = tostring(CustomHeaders[selectedParam])\n    | extend totalTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).total_tokens\n    | summarize RequestCount=count(), TotalTokens=sum(todouble(totalTokens)) by SelectedParamValue;\nrequests\n| where operation_Name == \"OpenAIProxy;rev=1 - Completions_Create\" or operation_Name == \"OpenAIProxy;rev=1 - ChatCompletions_Create\"\n| extend requestId = customDimensions.[\"Request Id\"]\n| extend Prompt = parse_json(tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Request-Body\"])).messages[-1].content))))\n| extend Generation = parse_json(tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).choices))[0].message)).content\n| extend promptTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).prompt_tokens\n| extend completionTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).completion_tokens\n| extend totalTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).total_tokens\n| extend CustomHeaders = parse_json(tostring(customDimensions.[\"Request-custom-headers\"]))\n| extend SelectedParamValue = tostring(CustomHeaders[selectedParam])\n| join kind=inner (summary) on SelectedParamValue\n| project SelectedParamValue, RequestCount, TotalTokens, timestamp, requestId, Prompt, Generation, promptTokens, completionTokens, totalTokens, round(duration,2)",
+                            "size": 0,
+                            "timeContext": {
+                                "durationMs": 86400000
+                            },
+                            "queryType": 0,
+                            "resourceType": "microsoft.insights/components",
+                            "gridSettings": {
+                                "formatters": [
+                                    {
+                                        "columnMatch": "$gen_group",
+                                        "formatter": 0,
+                                        "formatOptions": {
+                                            "customColumnWidthSetting": "24ch"
+                                        }
+                                    },
+                                    {
+                                        "columnMatch": "SelectedParamValue",
+                                        "formatter": 5
+                                    },
+                                    {
+                                        "columnMatch": "requestId",
+                                        "formatter": 5
+                                    },
+                                    {
+                                        "columnMatch": "-- Group By --",
+                                        "formatter": 0,
+                                        "formatOptions": {
+                                            "customColumnWidthSetting": "24ch"
+                                        }
+                                    },
+                                    {
+                                        "columnMatch": "Grouper",
+                                        "formatter": 5,
+                                        "formatOptions": {
+                                            "customColumnWidthSetting": "12ch"
+                                        }
+                                    }
+                                ],
+                                "hierarchySettings": {
+                                    "treeType": 1,
+                                    "groupBy": [
+                                        "SelectedParamValue"
+                                    ],
+                                    "expandTopLevel": false,
+                                    "finalBy": "SelectedParamValue"
+                                },
+                                "labelSettings": [
+                                    {
+                                        "columnId": "SelectedParamValue",
+                                        "label": "Selected Value"
+                                    },
+                                    {
+                                        "columnId": "RequestCount",
+                                        "label": "# Requests"
+                                    },
+                                    {
+                                        "columnId": "TotalTokens",
+                                        "label": "Total Tokens"
+                                    }
+                                ]
+                            }
+                        },
+                        "name": "query - 9"
                     }
                 ]
             },
-            "name": "query - 2",
-            "styleSettings": {
-                "showBorder": true
-            }
+            "name": "group - 10"
         },
         {
-            "type": 3,
+            "type": 1,
             "content": {
-                "version": "KqlItem/1.0",
-                "query": "let SelectedRequest = '{SelectedRequest}';\nlet MetaData = requests\n| where tostring(customDimensions.[\"Request Id\"]) == SelectedRequest or SelectedRequest == 'ALL'\n| extend Duration = tostring(round(duration,2)), Success = tostring(success), PerformanceBucket = tostring(performanceBucket)\n| extend RequestSize = tostring(customMeasurements[\"Request Size\"]), ResponseSize = tostring(customMeasurements[\"Response Size\"])\n| extend Model = tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).model)))\n| extend OperationName = tostring(customDimensions[\"Operation Name\"])\n| extend UsageData = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage))\n| extend TotalTokens = tostring(UsageData[\"total_tokens\"]), CompletionTokens = tostring(UsageData[\"completion_tokens\"]), PromptTokens = tostring(UsageData[\"prompt_tokens\"])\n| project Metadata=strcat(\"|&nbsp;|&nbsp;|\\n|--:|--|\\n\", \"| **Duration** | \", Duration, \" ms |\\n| **Success** | \", Success, \"|\\n| **Request Size** | \", RequestSize, \" bytes |\\n| **Response Size** | \", ResponseSize, \" bytes |\\n| **Total Tokens** | \", TotalTokens, \" |\\n| **Completion Tokens** | \", CompletionTokens, \" |\\n| **Prompt Tokens** | \", PromptTokens, \"|\\n| **Performance Bucket** | \", PerformanceBucket, \"|\\n| **Model** | \", Model, \"|\\n| **Operation Name** | \", OperationName, \" |\");\n\nMetaData\n",
-                "size": 0,
-                "title": "Request Metadata",
-                "noDataMessage": "Select a request in the table above to see details.",
-                "timeContext": {
-                    "durationMs": 86400000
-                },
-                "queryType": 0,
-                "resourceType": "microsoft.insights/components",
-                "visualization": "card",
-                "textSettings": {
-                    "style": "markdown"
-                }
+                "json": "# OpenAI Request Logger\n---\n"
             },
-            "customWidth": "0",
-            "name": "Request Metadata",
-            "styleSettings": {
-                "margin": "0",
-                "maxWidth": "30%"
-            }
-        },
-        {
-            "type": 3,
-            "content": {
-                "version": "KqlItem/1.0",
-                "query": "let SelectedRequest = '{SelectedRequest}';\nlet SystemMessages = requests\n| where customDimensions.[\"Request Id\"] == SelectedRequest or 'ALL' == SelectedRequest\n| extend MessagesArray = parse_json(tostring(parse_json(tostring(customDimensions.[\"Request-Body\"])).messages))\n| mv-expand MessagesArray\n| where tostring(MessagesArray[\"role\"]) == \"system\"\n| project ChatHistoryRow=strcat(\"🔔 **System**: \", tostring(MessagesArray[\"content\"]), \"\\n\"), Order=1;\n\nlet UserAndAssistantMessages = requests\n| where customDimensions.[\"Request Id\"] == SelectedRequest or 'ALL' == SelectedRequest\n| extend MessagesArray = parse_json(tostring(parse_json(tostring(customDimensions.[\"Request-Body\"])).messages))\n| mv-expand MessagesArray\n| where tostring(MessagesArray[\"role\"]) != \"system\"\n| extend Role = tostring(MessagesArray[\"role\"]), Content = tostring(MessagesArray[\"content\"])\n| extend Symbol = iif(Role == \"assistant\", \"🤖 \", \"👤 \")\n| project ChatHistoryRow=strcat(Symbol, \"**\", iif(Role == \"assistant\", \"Assistant\", \"User\"), \"**: \", Content, \"\\n\"), Order=2;\n\nlet FinalResponse = requests\n| where customDimensions.[\"Request Id\"] == SelectedRequest or 'ALL' == SelectedRequest\n| extend Generation = parse_json(tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).choices))[0].message)).content\n| project ChatHistoryRow=strcat(\"🤖 **Assistant**: \", Generation, \"\\n\"), Order=3;\n\nSystemMessages\n| union UserAndAssistantMessages, FinalResponse\n| order by Order asc\n| summarize ChatHistory=strcat_array(makelist(ChatHistoryRow), \"\\n\")\n",
-                "size": 0,
-                "title": "Request History",
-                "noDataMessage": "Select a request in the table above to see details.",
-                "timeContext": {
-                    "durationMs": 86400000
-                },
-                "queryType": 0,
-                "resourceType": "microsoft.insights/components",
-                "visualization": "card",
-                "textSettings": {
-                    "style": "markdown"
-                }
-            },
-            "customWidth": "65",
-            "name": "Request History",
-            "styleSettings": {
-                "margin": "0",
-                "padding": "12px",
-                "showBorder": true
-            }
+            "name": "text - 2"
         },
         {
             "type": 3,
@@ -151,6 +167,219 @@
             },
             "customWidth": "50",
             "name": "Average response time"
+        },
+        {
+            "type": 3,
+            "content": {
+                "version": "KqlItem/1.0",
+                "query": "requests\n| summarize Count=count() by bin(timestamp, 1d), performanceBucket\n| extend BucketOrder = case(\n    performanceBucket == \"<250ms\", 1,\n    performanceBucket == \"250ms-500ms\", 2,\n    performanceBucket == \"500ms-1sec\", 3,\n    performanceBucket == \"1sec-3sec\", 4,\n    performanceBucket == \"3sec-7sec\", 5,\n    performanceBucket == \"7sec-15sec\", 6,\n    performanceBucket == \"15sec-30sec\", 7,\n    performanceBucket == \">30sec\", 8,\n    0\n)\n| project performanceBucket, Count, BucketOrder\n| order by BucketOrder asc\n",
+                "size": 0,
+                "title": "Performance buckets",
+                "timeContext": {
+                    "durationMs": 86400000
+                },
+                "exportFieldName": "x",
+                "exportParameterName": "PerformanceBucketFilter",
+                "exportDefaultValue": "All",
+                "queryType": 0,
+                "resourceType": "microsoft.insights/components",
+                "visualization": "barchart",
+                "gridSettings": {
+                    "formatters": [
+                        {
+                            "columnMatch": "Count",
+                            "formatter": 8,
+                            "formatOptions": {
+                                "palette": "hotCold"
+                            }
+                        }
+                    ]
+                },
+                "tileSettings": {
+                    "showBorder": false,
+                    "titleContent": {
+                        "columnMatch": "performanceBucket",
+                        "formatter": 1
+                    },
+                    "leftContent": {
+                        "columnMatch": "Count",
+                        "formatter": 12,
+                        "formatOptions": {
+                            "palette": "auto"
+                        },
+                        "numberFormat": {
+                            "unit": 17,
+                            "options": {
+                                "maximumSignificantDigits": 3,
+                                "maximumFractionDigits": 2
+                            }
+                        }
+                    }
+                },
+                "chartSettings": {
+                    "xAxis": "performanceBucket",
+                    "yAxis": [
+                        "Count"
+                    ],
+                    "showLegend": true,
+                    "seriesLabelSettings": [
+                        {
+                            "seriesName": "<250ms",
+                            "color": "amethyst"
+                        },
+                        {
+                            "seriesName": "250ms-500ms",
+                            "color": "blue"
+                        },
+                        {
+                            "seriesName": "500ms-1sec",
+                            "color": "green"
+                        },
+                        {
+                            "seriesName": "1sec-3sec",
+                            "color": "turquoise"
+                        },
+                        {
+                            "seriesName": "3sec-7sec",
+                            "color": "orange"
+                        },
+                        {
+                            "seriesName": "7sec-15sec",
+                            "color": "redBright"
+                        }
+                    ]
+                }
+            },
+            "customWidth": "50",
+            "name": "Performance buckets"
+        },
+        {
+            "type": 1,
+            "content": {
+                "json": "\n&nbsp;\n\n&nbsp;\n\n&nbsp;\n\n&nbsp;\n\n\n# Placeholder for metric ideas\n- average tokens per request (prompt / completion / total?)\n- avg cost per request? (assumption in model)\n- perhaps remove the avg response time line chart, in favor of performance bucket bar chart\n\n"
+            },
+            "customWidth": "50",
+            "name": "text - 9"
+        },
+        {
+            "type": 1,
+            "content": {
+                "json": "# Usage\n### Click on a performance bucket above to filter requests by bucket.\n### Click on a row below to view the details of that request.\n",
+                "style": "info"
+            },
+            "name": "text - 6"
+        },
+        {
+            "type": 3,
+            "content": {
+                "version": "KqlItem/1.0",
+                "query": "let PerformanceBucketFilter = '{PerformanceBucketFilter}';\n\nrequests\n| where operation_Name == \"OpenAIProxy;rev=1 - Completions_Create\" or operation_Name == \"OpenAIProxy;rev=1 - ChatCompletions_Create\"\n| where PerformanceBucketFilter == \"All\" or performanceBucket == PerformanceBucketFilter\n| extend requestId = customDimensions.[\"Request Id\"]\n| extend Prompt = parse_json(tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Request-Body\"])).messages[-1].content))))\n| extend Generation = parse_json(tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).choices))[0].message)).content\n| extend promptTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).prompt_tokens\n| extend completionTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).completion_tokens\n| extend totalTokens = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage)).total_tokens\n| extend CustomHeaders = customDimensions.[\"Request-custom-headers\"]\n| project timestamp, requestId, Prompt, Generation, promptTokens, completionTokens, totalTokens, round(duration,2), CustomHeaders, operation_Name\n",
+                "size": 0,
+                "title": "Requests table",
+                "showRefreshButton": true,
+                "exportFieldName": "requestId",
+                "exportParameterName": "SelectedRequest",
+                "exportDefaultValue": "none",
+                "exportToExcelOptions": "all",
+                "queryType": 0,
+                "resourceType": "microsoft.insights/components",
+                "gridSettings": {
+                    "formatters": [
+                        {
+                            "columnMatch": "requestId",
+                            "formatter": 5
+                        }
+                    ],
+                    "filter": true,
+                    "sortBy": [
+                        {
+                            "itemKey": "timestamp",
+                            "sortOrder": 2
+                        }
+                    ]
+                },
+                "sortBy": [
+                    {
+                        "itemKey": "timestamp",
+                        "sortOrder": 2
+                    }
+                ]
+            },
+            "name": "Requests table",
+            "styleSettings": {
+                "showBorder": true
+            }
+        },
+        {
+            "type": 3,
+            "content": {
+                "version": "KqlItem/1.0",
+                "query": "let SelectedRequest = '{SelectedRequest}';\nlet MetaData = requests\n| where tostring(customDimensions.[\"Request Id\"]) == SelectedRequest or SelectedRequest == 'ALL'\n| extend Duration = tostring(round(duration,2)), Success = tostring(success), PerformanceBucket = tostring(performanceBucket)\n| extend RequestSize = tostring(customMeasurements[\"Request Size\"]), ResponseSize = tostring(customMeasurements[\"Response Size\"])\n| extend Model = tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).model)))\n| extend OperationName = tostring(customDimensions[\"Operation Name\"])\n| extend UsageData = parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).usage))\n| extend TotalTokens = toreal(UsageData[\"total_tokens\"]), CompletionTokens = toreal(UsageData[\"completion_tokens\"]), PromptTokens = toreal(UsageData[\"prompt_tokens\"])\n| extend PromptCost = iif(Model == \"gpt-35-turbo\", (PromptTokens/1000) * 0.0015, iif(Model == \"gpt-4\", (PromptTokens/1000) * 0.03, 0.0))\n| extend CompletionCost = iif(Model == \"gpt-35-turbo\", (CompletionTokens/1000) * 0.002, iif(Model == \"gpt-4\", (CompletionTokens/1000) * 0.06, 0.0))\n| extend EstimatedCost = PromptCost + CompletionCost\n| project Metadata=strcat(\"|&nbsp;|&nbsp;|\\n|--:|--|\\n\", \"| **Duration** | \", Duration, \" ms |\\n| **Success** | \", Success, \"|\\n| **Request Size** | \", RequestSize, \" bytes |\\n| **Response Size** | \", ResponseSize, \" bytes |\\n| **Total Tokens** | \", tostring(TotalTokens), \" |\\n| **Completion Tokens** | \", tostring(CompletionTokens), \" |\\n| **Prompt Tokens** | \", tostring(PromptTokens), \"|\\n| **Performance Bucket** | \", PerformanceBucket, \"|\\n| **Model** | \", Model, \"|\\n| **Operation Name** | \", OperationName, \" |\\n| **Estimated Cost** <br><small>assumes gpt-35-turbo <br>or gpt-4, no discounts</small> | $\", tostring(round(EstimatedCost, 4)), \" |\");\n\nMetaData\n",
+                "size": 0,
+                "title": "Request Metadata",
+                "noDataMessage": "Select a request in the table above to see details.",
+                "timeContext": {
+                    "durationMs": 86400000
+                },
+                "queryType": 0,
+                "resourceType": "microsoft.insights/components",
+                "visualization": "card",
+                "textSettings": {
+                    "style": "markdown"
+                }
+            },
+            "conditionalVisibility": {
+                "parameterName": "SelectedRequest",
+                "comparison": "isNotEqualTo",
+                "value": "none"
+            },
+            "customWidth": "0",
+            "name": "Request Metadata",
+            "styleSettings": {
+                "margin": "0",
+                "maxWidth": "30%"
+            }
+        },
+        {
+            "type": 3,
+            "content": {
+                "version": "KqlItem/1.0",
+                "query": "let SelectedRequest = '{SelectedRequest}';\nlet SystemMessages = requests\n| where customDimensions.[\"Request Id\"] == SelectedRequest or 'ALL' == SelectedRequest\n| extend MessagesArray = parse_json(tostring(parse_json(tostring(customDimensions.[\"Request-Body\"])).messages))\n| mv-expand MessagesArray\n| where tostring(MessagesArray[\"role\"]) == \"system\"\n| project ChatHistoryRow=strcat(\"🔔 **System**: \", tostring(MessagesArray[\"content\"]), \"\\n\"), Order=1;\n\nlet UserAndAssistantMessages = requests\n| where customDimensions.[\"Request Id\"] == SelectedRequest or 'ALL' == SelectedRequest\n| extend MessagesArray = parse_json(tostring(parse_json(tostring(customDimensions.[\"Request-Body\"])).messages))\n| mv-expand MessagesArray\n| where tostring(MessagesArray[\"role\"]) != \"system\"\n| extend Role = tostring(MessagesArray[\"role\"]), Content = tostring(MessagesArray[\"content\"])\n| extend Symbol = iif(Role == \"assistant\", \"🤖 \", \"👤 \")\n| project ChatHistoryRow=strcat(Symbol, \"**\", iif(Role == \"assistant\", \"Assistant\", \"User\"), \"**: \", Content, \"\\n\"), Order=2;\n\nlet FinalResponse = requests\n| where customDimensions.[\"Request Id\"] == SelectedRequest or 'ALL' == SelectedRequest\n| extend Generation = parse_json(tostring(parse_json(tostring(parse_json(tostring(customDimensions.[\"Response-Body\"])).choices))[0].message)).content\n| project ChatHistoryRow=strcat(\"🤖 **Assistant**: \", Generation, \"\\n\"), Order=3;\n\nSystemMessages\n| union UserAndAssistantMessages, FinalResponse\n| order by Order asc\n| summarize ChatHistory=strcat_array(makelist(ChatHistoryRow), \"\\n\")\n",
+                "size": 0,
+                "title": "Request History",
+                "noDataMessage": "Select a request in the table above to see details.",
+                "timeContext": {
+                    "durationMs": 86400000
+                },
+                "queryType": 0,
+                "resourceType": "microsoft.insights/components",
+                "visualization": "card",
+                "textSettings": {
+                    "style": "markdown"
+                }
+            },
+            "conditionalVisibility": {
+                "parameterName": "SelectedRequest",
+                "comparison": "isNotEqualTo",
+                "value": "none"
+            },
+            "customWidth": "65",
+            "name": "Request History",
+            "styleSettings": {
+                "margin": "0",
+                "padding": "12px",
+                "showBorder": true
+            }
+        },
+        {
+            "type": 1,
+            "content": {
+                "json": "&nbsp;\n\n&nbsp;\n\n&nbsp;\n\n🚀 Thanks for using this tool! Please drop any feedback or suggestions in the [GitHub repo](https://github.com/aavetis/azure-openai-logger).\n\n\nWant to collaborate? Find me on [Twitter](https://twitter.com/albfresco) or [LinkedIn](https://www.linkedin.com/in/albert-avetisian).\n\n– albs\n\n"
+            },
+            "name": "text - 10",
+            "styleSettings": {
+                "padding": "24px"
+            }
         }
     ],
     "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"


### PR DESCRIPTION
- Improved main requests query
- Added performance buckets bar chart, with the ability to filter requests table when you click on a bucket (e.g., only show me requests with >3 second response time)
- Added (hidden) section for now that will house the ability to group requests by custom properties
- Added `custom-headers` to get logged if they are passed through requests